### PR TITLE
Include the LICENSE.txt in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt


### PR DESCRIPTION
To show the redistribution rights. Makes it easier to create conda recipe from pypi release tarball.